### PR TITLE
Fix legacy peh.sh commands not working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ GOPROXY=direct go install github.com/pndlm/peh/helper/peh@latest
 ```bash
 GOPROXY=direct go get github.com/pndlm/peh/peh3
 ```
+
+## Build the helper
+
+```bash
+go build ./helper/peh
+```

--- a/helper/peh/main.go
+++ b/helper/peh/main.go
@@ -43,7 +43,7 @@ func main() {
 		if _, err := os.Stat(shPath); err == nil {
 			// run found peh.sh
 			projectDir = dir
-			cmdName = "peh.sh"
+			cmdName = "./peh.sh"
 			break
 		}
 		dir = filepath.Dir(dir)


### PR DESCRIPTION
It looks like this code should work to run the legacy peh.sh when it is there, but it wasn't working for me so I had to make this change.